### PR TITLE
makefile: Add path to new homebrew location on Apple Silicon macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ ifdef CONFIG_SLIRP
 override CFLAGS+=-DCONFIG_SLIRP
 ifdef CONFIG_MACOS
 override LDFLAGS+=-lresolv
+override CFLAGS+=-I/opt/homebrew/include
+override LDFLAGS+=-L/opt/homebrew/lib
 endif # CONFIG_MACOS
 EMU_OBJS+=$(addprefix slirp/, bootp.o ip_icmp.o mbuf.o slirp.o tcp_output.o cksum.o ip_input.o misc.o socket.o tcp_subr.o udp.o if.o ip_output.o sbuf.o tcp_input.o tcp_timer.o)
 endif # CONFIG_SLIRP


### PR DESCRIPTION
The project wouldn't build on my M1 MacBook unless we add the right paths.