### PR TITLE
Allow compilation with emscripten 3.1.46

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -24,9 +24,9 @@
 
 # Build the Javascript version of TinyEMU
 EMCC=emcc
-EMCFLAGS=-O2 --llvm-opts 2 -Wall -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -MMD -fno-strict-aliasing -DCONFIG_FS_NET
+EMCFLAGS=-O2 -Wall -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -MMD -fno-strict-aliasing -DCONFIG_FS_NET
 #EMCFLAGS+=-Werror
-EMLDFLAGS=-O3 --memory-init-file 0 --closure 0 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s "EXPORTED_FUNCTIONS=['_console_queue_char','_vm_start','_fs_import_file','_display_key_event','_display_mouse_event','_display_wheel_event','_net_write_packet','_net_set_carrier']" -s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]' -s BINARYEN_TRAP_MODE=clamp --js-library js/lib.js
+EMLDFLAGS=-O3 --memory-init-file 0 --closure 0 -s NO_EXIT_RUNTIME=1 -s NO_FILESYSTEM=1 -s "EXPORTED_FUNCTIONS=['_console_queue_char','_vm_start','_fs_import_file','_display_key_event','_display_mouse_event','_display_wheel_event','_net_write_packet','_net_set_carrier','_free']" -s 'DYNCALLS=1'  -s 'EXPORTED_RUNTIME_METHODS=["ccall", "cwrap", "UTF8ToString"]' --js-library js/lib.js
 EMLDFLAGS_ASMJS:=$(EMLDFLAGS) -s WASM=0
 EMLDFLAGS_WASM:=$(EMLDFLAGS) -s WASM=1 -s TOTAL_MEMORY=67108864 -s ALLOW_MEMORY_GROWTH=1
 

--- a/js/lib.js
+++ b/js/lib.js
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-mergeInto(LibraryManager.library, {
+addToLibrary({
     console_write: function(opaque, buf, len)
     {
         var str;
@@ -41,7 +41,7 @@ mergeInto(LibraryManager.library, {
 
     fs_export_file: function(filename, buf, buf_len)
     {
-        var _filename = Pointer_stringify(filename);
+        var _filename = UTF8ToString(filename);
 //        console.log("exporting " + _filename);
         var data = HEAPU8.subarray(buf, buf + buf_len);
         var file = new Blob([data], { type: "application/octet-stream" });
@@ -58,20 +58,21 @@ mergeInto(LibraryManager.library, {
         }, 50);
     },
 
+    emscripten_async_wget3_data__deps: [ "$wget", "$Browser" ],
     emscripten_async_wget3_data: function(url, request, user, password, post_data, post_data_len, arg, free, onload, onerror, onprogress) {
-    var _url = Pointer_stringify(url);
-    var _request = Pointer_stringify(request);
+    var _url = UTF8ToString(url);
+    var _request = UTF8ToString(request);
     var _user;
     var _password;
 
       var http = new XMLHttpRequest();
 
       if (user)
-          _user = Pointer_stringify(user);
+          _user = UTF8ToString(user);
       else
           _user = null;
       if (password)
-          _password = Pointer_stringify(password);
+          _password = UTF8ToString(password);
       else
           _password = null;
         
@@ -81,7 +82,7 @@ mergeInto(LibraryManager.library, {
           http.setRequestHeader("Authorization", "Basic " + btoa(_user + ':' + _password));
       }
         
-    var handle = Browser.getNextWgetRequestHandle();
+    var handle = wget.getNextWgetRequestHandle();
 
     // LOAD
     http.onload = function http_onload(e) {
@@ -89,30 +90,30 @@ mergeInto(LibraryManager.library, {
         var byteArray = new Uint8Array(http.response);
         var buffer = _malloc(byteArray.length);
         HEAPU8.set(byteArray, buffer);
-        if (onload) Runtime.dynCall('viiii', onload, [handle, arg, buffer, byteArray.length]);
+        if (onload) dynCall('viiii', onload, [handle, arg, buffer, byteArray.length]);
         if (free) _free(buffer);
       } else {
-        if (onerror) Runtime.dynCall('viiii', onerror, [handle, arg, http.status, http.statusText]);
+        if (onerror) dynCall('viiii', onerror, [handle, arg, http.status, http.statusText]);
       }
-      delete Browser.wgetRequests[handle];
+      delete wget.wgetRequests[handle];
     };
 
     // ERROR
     http.onerror = function http_onerror(e) {
       if (onerror) {
-        Runtime.dynCall('viiii', onerror, [handle, arg, http.status, http.statusText]);
+        dynCall('viiii', onerror, [handle, arg, http.status, http.statusText]);
       }
-      delete Browser.wgetRequests[handle];
+      delete wget.wgetRequests[handle];
     };
 
     // PROGRESS
     http.onprogress = function http_onprogress(e) {
-      if (onprogress) Runtime.dynCall('viiii', onprogress, [handle, arg, e.loaded, e.lengthComputable || e.lengthComputable === undefined ? e.total : 0]);
+      if (onprogress) dynCall('viiii', onprogress, [handle, arg, e.loaded, e.lengthComputable || e.lengthComputable === undefined ? e.total : 0]);
     };
 
     // ABORT
     http.onabort = function http_onabort(e) {
-      delete Browser.wgetRequests[handle];
+      delete wget.wgetRequests[handle];
     };
 
     // Useful because the browser can limit the number of redirection
@@ -132,7 +133,7 @@ mergeInto(LibraryManager.library, {
       http.send(null);
     }
 
-    Browser.wgetRequests[handle] = http;
+    wget.wgetRequests[handle] = http;
 
     return handle;
   },


### PR DESCRIPTION
Some emscripten APIs have changed in a breaking way.

Change makefile.js and js/lib.js to allow the JavaScript code to be built again.

Change mergeInto to addToLibrary.
Change Pointer_stringify to UTF8ToString.
change Browser to wget.
Add __deps configuration.
Change Runtime.dynCall to dynCall.
Update compiler arguments.